### PR TITLE
Simplify getting package names.

### DIFF
--- a/packages.rb
+++ b/packages.rb
@@ -4,11 +4,10 @@
 IGNORED_PACKAGES = %w{
 }
 
-packages = `dnf repoquery --repoid=rawhide-source --arch=src --whatrequires 'ruby*'`
+packages = `dnf repoquery -q --disablerepo='*' --enablerepo=rawhide-source --arch=src --qf '%{name}' --whatrequires 'ruby*'`
 exit $?.to_i if $?.to_i != 0
 
-packages = packages.lines.to_a
-packages.map! { |package| package.strip[/(.*)-.*?-.*?/, 1] }
+packages = packages.lines
 packages.compact!
 packages.uniq!
 packages.sort!


### PR DESCRIPTION
List package names directly. No need to parse SRPMs names.