### PR TITLE
Remove empty element from packages

### DIFF
--- a/packages.rb
+++ b/packages.rb
@@ -11,7 +11,7 @@ packages = packages.lines
 packages.map!(&:strip)
 packages.uniq!
 packages.sort!
-packages.delete("\n")
+packages.delete('')
 
 packages = packages - IGNORED_PACKAGES
 


### PR DESCRIPTION
Unmatched lines from dnf output could result in empty element.
